### PR TITLE
Spellcheck, redo README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Mansalva
 This project involves the creation of an informal handwritten font to be used for making comments on lecture slides. It is a handwritten font that has good legibility and can be used for short notes or with other purposes, as it has a complete set of characters, including some languages support. Mansalva features two alternates for each letter to create a more natural handwritten look.
-![Mansalva Sample](https://raw.githubusercontent.com/carolinashort/mansalva/master/documentation/samples/Mansalva2021-sample2.png)
+![Mansalva Sample](/documentation/readme-images-2.png)
 
 
-The original aim of this project was to create a handwritten font that can be used for notes and informal text. It started as an experiment during idle time, and it turns out as a script with a good flow, so I’ve decided to develop the whole set. 
+The original aim of this project was to create a handwritten font that can be used for notes and informal text. It started as an experiment during idle time, and it turned out as a script with a good flow, so I’ve decided to develop the whole set. 
 I had a copy of FontSelf Maker that I always wanted to try, and it turned out to be an easy to use tool that will allow the creation of quick fonts and icons. So the beginning of this font was on FontSelf Maker with Adobe Illustrator. It’s easy to use, and I was surprised that provides many useful features as tracking and kerning tools. 
-Once the project was more advanced, I’ve decided to move onto Glyphs. The final development of the font, refinement and alternates was developed using Glyphs. 
+Once the project was more advanced, I decided to move onto Glyphs. The final development of the font, refinement and alternates was developed using Glyphs. 
 
-![Mansalva Sample](https://raw.githubusercontent.com/carolinashort/mansalva/master/documentation/samples/Mansalva2021-sample1.png)
+![Mansalva Sample](/documentation/readme-images-1.png)
 
-Mansalva gets its name from the Spanish expression _a mano salva_ that originally means “simply with your hand “. Nowadays, the expression _a mansalva_ is used to mean abundance, close range, or without risk. 
+Mansalva gets its name from the Spanish expression _a mano salva_ that originally means “simply with your hand“. Nowadays, the expression _a mansalva_ is used to mean abundance, close range, or without risk. 
 This version of the font was created using a regular marker. I plan to add more styles in the future, using different tools to make some other styles to match a _light_ weight. It is still a work in progress, critique and comments are welcome. 
 
-![Mansalva Sample](https://raw.githubusercontent.com/carolinashort/mansalva/master/documentation/samples/Mansalva2021-sample3.png)
+![Mansalva Sample](/documentation/readme-images-3.png)
 
 Recent updates include 2 sets of alternates, 2 sets for numbers, fixes in kerning and additional language support, such as better designed Māori macrons and other Pacifika languages.
 
 Para más información en castellano, ver el en directorio /documentation/_Mansalva español_
-![Mansalva en castellano](https://github.com/carolinashort/mansalva/blob/master/documentation/_Mansalva%20espa%C3%B1ol_/
+[Mansalva en castellano](/documentation/_Mansalva%20espa%C3%B1ol_/)


### PR DESCRIPTION
Links are supposed to be like this `[title](link)`, fixed image links to point directly to the repository by doing `![title](/documentation/image)`. Thanks for this great font! 